### PR TITLE
feat/#5 회원가입시 비동기로 유저 정보 최신화

### DIFF
--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/member/service/AsyncMemberService.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/member/service/AsyncMemberService.java
@@ -1,0 +1,28 @@
+package com.matching.ezgg.domain.member.service;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import com.matching.ezgg.domain.matching.service.MatchingService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AsyncMemberService {
+
+	private final MatchingService matchingService;
+
+	@Async("memberTaskExecutor")
+	public void updateMatchingAttributesAsync(Long memberId) {
+		try {
+			log.info("회원 매칭 속성 업데이트 시작 - memberId: {}", memberId);
+			matchingService.updateAllAttributesOfMember(memberId);
+			log.info("회원 매칭 속성 업데이트 완료 - memberId: {}", memberId);
+		} catch (Exception e) {
+			log.error("회원 매칭 속성 업데이트 실패 - memberId: {}", memberId, e);
+		}
+	}
+}

--- a/backend/ezgg/src/main/java/com/matching/ezgg/domain/member/service/MemberService.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/domain/member/service/MemberService.java
@@ -39,6 +39,7 @@ public class MemberService {
 	private final MemberInfoRepository memberInfoRepository;
 	private final JWTUtil jwtUtil;
 	private final RedisRefreshTokenRepository redisRefreshTokenRepository;
+	private final AsyncMemberService asyncMemberService;
 
 	private final PasswordEncoder passwordEncoder;
 
@@ -74,6 +75,8 @@ public class MemberService {
 		String newPuuid = apiService.getMemberPuuid(signupRequest.getRiotUsername(), signupRequest.getRiotTag());
 		MemberInfo memberInfo = memberInfoService.createNewMemberInfo(member.getId(), signupRequest.getRiotUsername(),
 			signupRequest.getRiotTag(), newPuuid);
+
+		asyncMemberService.updateMatchingAttributesAsync(member.getId());
 
 		return SignupResponse.builder()
 			.memberUsername(member.getMemberUsername())

--- a/backend/ezgg/src/main/java/com/matching/ezgg/global/config/AsyncConfig.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/global/config/AsyncConfig.java
@@ -1,0 +1,26 @@
+package com.matching.ezgg.global.config;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+	@Bean(name = "memberTaskExecutor")
+	public Executor memberTaskExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(2);                //최소 2개 스레드 유지
+		executor.setMaxPoolSize(5);                    //최대 5개 스레드 사용
+		executor.setQueueCapacity(50);                //대기열 50개 까지
+		executor.setThreadNamePrefix("Member-");    //로그에서 스레드이름구분
+		executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy()); // 큐가 가득 찰 때 처리
+		executor.initialize();
+		return executor;
+	}
+}

--- a/backend/ezgg/src/test/java/com/matching/ezgg/domain/member/service/MemberServiceTest.java
+++ b/backend/ezgg/src/test/java/com/matching/ezgg/domain/member/service/MemberServiceTest.java
@@ -52,6 +52,8 @@ class MemberServiceTest {
 	private RedisRefreshTokenRepository redisRefreshTokenRepository;
 	@Mock
 	private PasswordEncoder passwordEncoder;
+	@Mock
+	private AsyncMemberService asyncMemberService;
 
 	@InjectMocks
 	private MemberService memberService;
@@ -143,6 +145,7 @@ class MemberServiceTest {
 			() -> verify(memberRepository).save(any(Member.class)),
 			() -> verify(apiService).getMemberPuuid(validSignupRequest.getRiotUsername(),
 				validSignupRequest.getRiotTag()),
+			() -> verify(asyncMemberService).updateMatchingAttributesAsync(mockMember.getId()),
 			() -> verify(memberInfoService).createNewMemberInfo(mockMember.getId(),
 				validSignupRequest.getRiotUsername(), validSignupRequest.getRiotTag(), expectedPuuId)
 		);


### PR DESCRIPTION

## 🔎 작업 내용

- 회원가입시 최근 20경기 및 티어 와 같은 api를 이용한 정보 비동기로 최신화
- 이를 위해 AsyncConfig, AsyncMemberService 생성
- 테스트코드에도 반영

## 🔧 앞으로의 과제

- 없음
